### PR TITLE
Allow transitions in callbacks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,10 @@
 
 package fsm
 
+import (
+	"context"
+)
+
 // InvalidEventError is returned by FSM.Event() when the event cannot be called
 // in the current state.
 type InvalidEventError struct {
@@ -82,6 +86,9 @@ func (e CanceledError) Error() string {
 // asynchronous state transition.
 type AsyncError struct {
 	Err error
+
+	Ctx              context.Context
+	CancelTransition func()
 }
 
 func (e AsyncError) Error() string {

--- a/uncancel_context.go
+++ b/uncancel_context.go
@@ -1,0 +1,21 @@
+package fsm
+
+import (
+	"context"
+	"time"
+)
+
+type uncancel struct {
+	context.Context
+}
+
+func (*uncancel) Deadline() (deadline time.Time, ok bool) { return }
+func (*uncancel) Done() <-chan struct{}                   { return nil }
+func (*uncancel) Err() error                              { return nil }
+
+// uncancelContext returns a context which ignores the cancellation of the parent and only keeps the values.
+// Also returns a new cancel function.
+// This is useful to keep a background task running while the initial request is finished.
+func uncancelContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(&uncancel{ctx})
+}

--- a/uncancel_context_test.go
+++ b/uncancel_context_test.go
@@ -1,0 +1,91 @@
+package fsm
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUncancel(t *testing.T) {
+	t.Run("create a new context", func(t *testing.T) {
+		t.Run("and cancel it", func(t *testing.T) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, "key1", "value1")
+			ctx, cancelFunc := context.WithCancel(ctx)
+			cancelFunc()
+
+			if ctx.Err() != context.Canceled {
+				t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+			}
+			select {
+			case <-ctx.Done():
+			default:
+				t.Error("expected context to be done but it wasn't")
+			}
+
+			t.Run("and uncancel it", func(t *testing.T) {
+				ctx, newCancelFunc := uncancelContext(ctx)
+				if ctx.Err() != nil {
+					t.Errorf("expected context error to be nil, got %v", ctx.Err())
+				}
+				select {
+				case <-ctx.Done():
+					t.Fail()
+				default:
+				}
+
+				t.Run("now it should still contain the values", func(t *testing.T) {
+					if ctx.Value("key1") != "value1" {
+						t.Errorf("expected context value of key 'key1' to be 'value1', got %v", ctx.Value("key1"))
+					}
+				})
+				t.Run("and cancel the child", func(t *testing.T) {
+					newCancelFunc()
+					if ctx.Err() != context.Canceled {
+						t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+					}
+					select {
+					case <-ctx.Done():
+					default:
+						t.Error("expected context to be done but it wasn't")
+					}
+				})
+			})
+		})
+		t.Run("and uncancel it", func(t *testing.T) {
+			ctx := context.Background()
+			parent := ctx
+			ctx, newCancelFunc := uncancelContext(ctx)
+			if ctx.Err() != nil {
+				t.Errorf("expected context error to be nil, got %v", ctx.Err())
+			}
+			select {
+			case <-ctx.Done():
+				t.Fail()
+			default:
+			}
+
+			t.Run("and cancel the child", func(t *testing.T) {
+				newCancelFunc()
+				if ctx.Err() != context.Canceled {
+					t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+				}
+				select {
+				case <-ctx.Done():
+				default:
+					t.Error("expected context to be done but it wasn't")
+				}
+
+				t.Run("and ensure the parent is not affected", func(t *testing.T) {
+					if parent.Err() != nil {
+						t.Errorf("expected parent context error to be nil, got %v", ctx.Err())
+					}
+					select {
+					case <-parent.Done():
+						t.Fail()
+					default:
+					}
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
This fixes looplab/fsm#43 and looplab/fsm#61.

This contains breaking changes, namely:
- signature change of `fsm.Event()` from `name string, ...args` to `ctx context.Context, name string, ...args`
- signature change of event handlers from `e *fsm.Event` to `ctx context.Context, e *fsm.Event` (refs looplab/fsm#61)

This allows state transitions to happen in enter state and after event callbacks:

https://github.com/alfaview/fsm/blob/d8a0147d791af007b0cb9eeb233e108392c1db3f/fsm_test.go#L672-L711